### PR TITLE
Ensure container is always rendered in front

### DIFF
--- a/autocomplete.css
+++ b/autocomplete.css
@@ -4,6 +4,7 @@
     border-radius: 3px;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
     min-width: 180px;
+    z-index: 1000;
 }
 
 .-autocomplete-list {


### PR DESCRIPTION
The default behavior of the autocomplete widget was to render it behind other form elements on the page.

![autocomplete-bug](https://f.cloud.github.com/assets/442971/1525313/cf794e64-4bd3-11e3-8c6b-21c1f8c09118.png)

This PR sets the z-index of the autocomplete container higher so it should be displayed in front of other elements.
