### PR TITLE
Escape regular expression token

### DIFF
--- a/autocomplete-client.coffee
+++ b/autocomplete-client.coffee
@@ -20,7 +20,7 @@ isWholeField = (rule) ->
 getRegExp = (rule) ->
   unless isWholeField(rule)
     # Expressions for the range from the last word break to the current cursor position
-    new RegExp('(^|\\b|\\s)' + rule.token + '([\\w.]*)$')
+    new RegExp('(^|\\b|\\s)\\' + rule.token + '([\\w.]*)$')
   else
     # Whole-field behavior - word characters or spaces
     new RegExp('(^)(.*)$')


### PR DESCRIPTION
Some tokens like "$" or "*" would not work as a matching
token because of their special uses in regular expressions.
Adding an escape before the token allows a much broader
range.
